### PR TITLE
Debian/rules: Apply workarounds for Jammy to all

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -34,10 +34,10 @@ override_dh_auto_clean:
 	rm -rf ${SRC_ROOT_DIR}/output
 
 ${SRC_ROOT_DIR}/output/bazel:
+	if [ -f /usr/bin/python3 ]; then ln -s /usr/bin/python3 python; fi; \
+	sed -i "s|gettid(|__gettid(|" third_party/grpc/src/core/lib/gpr/log_linux.cc ; \
 	if [ -f /usr/bin/g++-10 ]; then \
 		echo "g++-10 found. using it to prevent using g++-11 or later"; \
-		sed -i "s|gettid(|__gettid(|" third_party/grpc/src/core/lib/gpr/log_linux.cc ; \
-		if [ -f /usr/bin/python3 ]; then ln -s /usr/bin/python3 python; fi; \
 		PATH=${PATH}:. CC=gcc-10 CXX=g++-10 EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk" ./compile.sh ; \
 	else \
 		EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk" ./compile.sh ; \


### PR DESCRIPTION
This patch applies the workarounds for Jammy to all as follows:
- Create a symbolic link for the python fallback
- Fix the error related to "ambiguating new declaration of 'long int gettid()'"

Signed-off-by: Wook Song <wook16.song@samsung.com>

Tested using ```pdebuild``` on Xenial, Bionic, Focal, and Jammy.